### PR TITLE
ci: Add conventional commits

### DIFF
--- a/.github/workflows/cc.yaml
+++ b/.github/workflows/cc.yaml
@@ -1,0 +1,17 @@
+name: Conventional-Commit-Lint
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-for-cc:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: check-for-cc
+        id: check-for-cc
+        uses: agenthunt/conventional-commit-checker-action@v1.0.0


### PR DESCRIPTION
Add conventional commit checking to all PRs

This will enforce all commits submitted by PR follow the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/).