### PR TITLE
ci: Add semantic releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+---
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Github release variables
+        run: |
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "GIT_AUTHOR_NAME=$GITHUB_ACTOR" >> $GITHUB_ENV
+          echo "GITHUB_USER=$GITHUB_ACTOR" >> $GITHUB_ENV
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13
+
+      - name: Install conventional commit plugin
+        run: npm install conventional-changelog-conventionalcommits
+
+      - name: Remove values files before packaging
+        run: rm -rf values/
+
+      - name: Release to Github
+        id: semantic
+        working-directory: ./.github/workflows
+        run: npx semantic-release@v17.2.2


### PR DESCRIPTION
Automatically creates releases according to conventional commits.

This allows for easy and automatic releases. It can later be integrated with docker to tag images according to the release.