### PR TITLE
ci: Fix semantic-release

### DIFF
--- a/.github/workflows/.releaserc.json
+++ b/.github/workflows/.releaserc.json
@@ -1,0 +1,18 @@
+{
+    "branches": ["main"],
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
+      "@semantic-release/github"
+    ]
+  }


### PR DESCRIPTION
Adds configuration file

Semantic release requires configuration in the `.releaserc.json`